### PR TITLE
Minor fixes

### DIFF
--- a/subunit.go
+++ b/subunit.go
@@ -191,7 +191,7 @@ func writeNumber(b io.Writer, num int) (err error) {
 		// Set the size to 11.
 		binary.Write(b, binary.BigEndian, uint32(num|0xc0000000))
 	default:
-		err = &ErrNumber(num)
+		err = &ErrNumber{num}
 	}
 
 	return err

--- a/subunit.go
+++ b/subunit.go
@@ -21,7 +21,6 @@
 package subunit
 
 import (
-	"errors"
 	"bytes"
 	"encoding/binary"
 	"fmt"
@@ -66,7 +65,7 @@ var status = map[string]byte{
 }
 
 func makeLen(baseLen int) (length int, err error) {
-	lenght = baseLen + 4 // Add the length of the CRC32.
+	length = baseLen + 4 // Add the length of the CRC32.
 	// We need to take into account the variable length of the length field itself.
 	switch {
 	case length <= 62:

--- a/subunit.go
+++ b/subunit.go
@@ -36,7 +36,7 @@ type ErrPacketLen struct {
 }
 	
 func (e *ErrPacketLen) Error() string {
-	return fmt.Errorf("packet too big (%d bytes)", e.Length)
+	return fmt.Sprintf("packet too big (%d bytes)", e.Length)
 }
 
 // ErrNumber represents an error for a number that is over the size
@@ -45,7 +45,7 @@ type ErrNumber struct {
 }
 	
 func (e *ErrNumber) Error() string {
-	return fmt.Errorf("number too big (%d)", e.Number)
+	return fmt.Sprintf("number too big (%d)", e.Number)
 }
 
 const (


### PR DESCRIPTION
len is a keyword, so I prefer avoiding it as a var name.
errors should return lower case strings to be easily composable in error messages, they shouldn't be the end user message itself (at least if not in package main). Ideally errors have a type.

I haven't tested these changes, just did them in the github web editor
